### PR TITLE
Update dependencies and compile targets to latest versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,16 +3,17 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.daggerHilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
     namespace = "com.michaelbentz.qriptid"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.michaelbentz.qriptid"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
 
@@ -32,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     buildFeatures {
         compose = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-agpPlugin = "8.5.1"
-kotlinPlugin = "1.9.22"
-kspPlugin = "1.9.22-1.0.17"
-coreKtx = "1.13.1"
-lifecycle = "2.8.3"
-work = "2.9.0"
-activityCompose = "1.9.0"
-navigationCompose = "2.7.7"
-composeBom = "2024.06.00"
+agpPlugin = "8.9.1"
+kotlinPlugin = "2.0.21"
+kspPlugin = "2.0.21-1.0.26"
+coreKtx = "1.15.0"
+lifecycle = "2.8.7"
+work = "2.10.0"
+activityCompose = "1.10.1"
+navigationCompose = "2.8.9"
+composeBom = "2025.03.00"
 room = "2.6.1"
 daggerHilt = "2.51"
 hiltNavigationCompose = "1.2.0"
@@ -24,6 +24,7 @@ androidApplication = { id = "com.android.application", version.ref = "agpPlugin"
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinPlugin" }
 daggerHilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspPlugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinPlugin" }
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 12 21:36:58 SAST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade AGP plugin from 8.5.1 to 8.9.1
- Upgrade Kotlin to 2.0.21 and related KSP plugin
- Bump Compose BOM to 2025.03.00 and add Compose compiler plugin
- Update AndroidX dependencies (core-ktx, lifecycle, activity-compose, work, navigation-compose)
- Increase compileSdk and targetSdk from 34 to 35
- Update Java compatibility from version 8 to 11
- Upgrade Gradle wrapper to version 8.11.1